### PR TITLE
fix(runbook): postgres password URL-safety fix

### DIFF
--- a/infra/runbooks/install-postgres.md
+++ b/infra/runbooks/install-postgres.md
@@ -339,8 +339,8 @@ sudo systemctl daemon-reload
 **No passwords are committed to this repo, ever.** The `<GENERATED_AT_DEPLOY>` placeholder in step 7 is replaced at deploy time with a freshly-generated password per role:
 
 ```bash
-PAPERCLIP_PG_PASSWORD=$(openssl rand -base64 32)
-WEFT_PG_PASSWORD=$(openssl rand -base64 32)
+PAPERCLIP_PG_PASSWORD=$(openssl rand -hex 32)
+WEFT_PG_PASSWORD=$(openssl rand -hex 32)
 
 sudo -u postgres psql -c "ALTER ROLE paperclip WITH PASSWORD '${PAPERCLIP_PG_PASSWORD}';"
 sudo -u postgres psql -c "ALTER ROLE weft      WITH PASSWORD '${WEFT_PG_PASSWORD}';"


### PR DESCRIPTION
## Summary

Resolves #8. Switches Postgres password generation from `openssl rand -base64 32` to `openssl rand -hex 32` to fix DATABASE_URL parsing compatibility.

## Why

Base64 encoding produces `+`, `/`, and `=` characters that are not URL-safe. Standard Postgres connection libraries (libpq, psycopg, sqlx, etc.) parse passwords from `DATABASE_URL` strings, where these characters require percent-encoding. Operators following the runbook would generate a password that needs additional encoding work before becoming usable in connection strings.

Hex encoding is URL-safe by definition (only `0-9a-f`), produces equally entropic output (256 bits from 32 random bytes), and is consistent with industry standard practice for secret generation in deployment runbooks.

## Scope

- `infra/runbooks/install-postgres.md` — two-line command replacement at lines 342-343 (one for the `paperclip` role password, one for the `weft` role password). No surrounding documentation in the runbook references base64 format, character counts, or encoding warnings, so the change is self-contained.

## Impact

- Future Postgres deployments using this runbook will generate hex passwords
- No impact on existing deployed databases (they keep their existing passwords until rotated per separate runbook)
- No CI/CD or test changes required

## Verification

Operator can run `openssl rand -hex 32` and confirm output is exactly 64 lowercase hex characters with no special characters. The output drops directly into `DATABASE_URL=postgres://user:<password>@host/db` without escaping.

## References

- Original finding: `docs/audit/2026-04-28-infrastructure-state-audit.md` (audit document line 342 finding, recommending `openssl rand -hex 32`)
- Issue: #8