### PR TITLE
docs(runbook): postgres install runbook polish bundle

### DIFF
--- a/infra/runbooks/install-postgres.md
+++ b/infra/runbooks/install-postgres.md
@@ -19,7 +19,7 @@ Two key decisions inherited from [ADR 0002](../../docs/adr/0002-postgres-single-
 
 - Ubuntu 24.04 LTS host with `sudo` access.
 - Hardened baseline already in place (Lynis ≥ 85, Tailscale-only ingress, no public TCP except those exposed deliberately via Tailscale Funnel).
-- ≥ 2 GB RAM available; ≥ 20 GB free at `/var/lib/postgresql/`.
+- ≥ 2 GB RAM available; ≥ 20 GB free at `/var/lib/postgresql/`. On the EL VPS (which co-hosts Restate, Weft, Paperclip), see [`install-restate.md`](install-restate.md) for the full-stack RAM minimum (≥ 4 GB).
 - At-rest disk encryption (LUKS or equivalent) on the data path. Postgres does not encrypt data files itself; full-disk encryption is the layer responsible.
 - The host clock is sane and NTP-synced. Backup timestamps and WAL ordering both depend on this.
 
@@ -32,7 +32,7 @@ If any of the above is not yet true, fix it before proceeding — none of these 
 The distribution-shipped Postgres lags the upstream release train by ~12 months. The official PostgreSQL Global Development Group (PGDG) repository ships current minor versions for every supported major. Pin to **PostgreSQL 16** — the current production-supported major as of April 2026, EOL November 2028 ([postgresql.org versioning policy](https://www.postgresql.org/support/versioning/)).
 
 ```bash
-sudo apt install -y curl ca-certificates gnupg lsb-release
+sudo apt update && sudo apt install -y curl ca-certificates lsb-release
 sudo install -d /usr/share/postgresql-common/pgdg
 sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
     -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
@@ -216,7 +216,7 @@ RETENTION_DAYS=14
 
 for db in paperclip weft; do
     out="${BACKUP_DIR}/${db}-${TIMESTAMP}.dump"
-    sudo -u postgres pg_dump --format=custom --no-owner --no-acl \
+    pg_dump --format=custom --no-owner --no-acl \
         --file="${out}" "${db}"
     chmod 0640 "${out}"
 done
@@ -225,7 +225,31 @@ done
 find "${BACKUP_DIR}" -type f -name '*.dump' -mtime +${RETENTION_DAYS} -delete
 ```
 
-Install:
+Write the script body above to `/tmp/postgres-backup.sh` (the literal contents of the code block, not just a placeholder):
+
+```bash
+cat > /tmp/postgres-backup.sh <<'BACKUP_SCRIPT_EOF'
+#!/usr/bin/env bash
+# Local nightly Postgres backup. Off-host shipping is a separate stage.
+set -euo pipefail
+
+BACKUP_DIR=/var/backups/postgresql
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+RETENTION_DAYS=14
+
+for db in paperclip weft; do
+    out="${BACKUP_DIR}/${db}-${TIMESTAMP}.dump"
+    pg_dump --format=custom --no-owner --no-acl \
+        --file="${out}" "${db}"
+    chmod 0640 "${out}"
+done
+
+# Prune backups older than RETENTION_DAYS.
+find "${BACKUP_DIR}" -type f -name '*.dump' -mtime +${RETENTION_DAYS} -delete
+BACKUP_SCRIPT_EOF
+```
+
+Install it into `/usr/local/bin/`:
 
 ```bash
 sudo install -m 0750 -o root -g postgres /tmp/postgres-backup.sh /usr/local/bin/postgres-backup.sh
@@ -241,6 +265,8 @@ Requires=postgresql@16-main.service
 
 [Service]
 Type=oneshot
+User=postgres
+Group=postgres
 ExecStart=/usr/local/bin/postgres-backup.sh
 ```
 


### PR DESCRIPTION
## Summary

Resolves #11. Phase E PR 1 of 4 — closes Postgres-runbook audit items 3, 4, 5, 6, 7 in a single bundled PR per `docs/planning/next-phases-scope.md` Phase E guidance.

| Audit item | Fix |
|---|---|
| 3 | Prepend `sudo apt update && ` to the curl/ca-certificates/lsb-release install line |
| 4 | Remove unused `gnupg` from the same install line (signed-by uses `.asc` directly; no `gpg --dearmor` step) |
| 5 | Add explicit heredoc step to write the backup script body to `/tmp/postgres-backup.sh` before the `install` command |
| 6 | Add `User=postgres` and `Group=postgres` to the backup systemd unit; drop redundant `sudo -u postgres` from the `pg_dump` invocation |
| 7 | Add full-stack RAM minimum cross-reference from Postgres runbook prereqs to `install-restate.md` (≥ 4 GB) |

## Why bundled

Each item is a 1-5-minute fix that touches the same file. Five separate PRs would create more review noise than signal. Single bundling issue (#11) covers all five with full audit context.

## Scope

Single file: `infra/runbooks/install-postgres.md`. +30 / -4 lines.

## What's intentionally out of scope

- Item 1 (Postgres password format) — already closed via PR #9
- Item 2 (hardened-baseline runbook prereq) — Phase F
- Item 8 (Paperclip Docker UID strategy ADR) — Phase G/I

The second `sudo apt install` (postgresql-16) further down already has its own `sudo apt update` between repo addition and install — out of scope per audit item 3 which targeted the first install line.

## Verification

- All five fixes located by grep in the modified file
- Anonymization grep clean: zero matches for `phantomz|levelop|agentpay|signal society|signal room`
- Diff scope: single file, single concern, no creep

## References

- Audit: `docs/audit/2026-04-28-infrastructure-state-audit.md` items 3, 4, 5, 6, 7
- Phase scope: `docs/planning/next-phases-scope.md` Phase E
- Issue: #11

Hard-stopped after PR opened per Phase E discipline. PR 2 (Restate template commit) will follow once this lands.