### PR TITLE
docs(contributing): add anonymization protocol for public artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,24 @@ If your issue does not match any template, the bug report template is the best d
 5. **Open the PR.** The repo's [pull request template](.github/PULL_REQUEST_TEMPLATE.md) walks through the discipline-check sections. Every section matters; "N/A" is acceptable when a section genuinely does not apply.
 6. **Respond to review.** The operator may approve, request changes, or request changes plus a revised approach. Treat review feedback as information, not as judgment — the goal is to land the right change, and the operator's review is the path to figuring out what that is.
 
+## Anonymization protocol for public artifacts
+
+The operator maintains a private brand exclusion list — the names of business entities, projects, and identities that the operator considers private context, never to be associated with this public repository. The list itself lives privately in the operator's vault and is never published.
+
+This protocol governs how that boundary is enforced in everyday contribution work.
+
+All public-facing content in this repository and in any linked public repositories — including PR bodies, commit messages, issue bodies, file contents, ADR text, runbook text, README content, and CHANGELOG entries — must never reference the operator's canonical private-brand exclusion list explicitly. Listing the strings in a verification note defeats the purpose of the verification.
+
+Verification language for anonymization grep checks must use this exact phrasing, in PR bodies and commit messages alike:
+
+> Anonymization grep clean — verified zero matches against canonical private-brand exclusion list at commit time. Operator maintains the canonical list privately.
+
+The grep command itself is run privately on the operator's machine or in ephemeral CI logs that are not committed to a public branch. The grep's pattern argument and any output that includes the matched strings are never echoed into committed content. The verification statement above is the only acceptable public artifact of the check.
+
+Failure to follow this protocol requires force-push correction of the affected commit (if the leak is on a feature branch and the branch has not yet merged) or close-and-reopen of the affected pull request from a clean branch (preferred when the residual exposure window matters more than preserving the existing PR number). For leaks on `main`, treat the incident as a real disclosure event: capture in the postmortem template, escalate to the operator immediately, and prefer a corrective commit with an honest CHANGELOG note over silent rewrites of public history.
+
+This protocol is also published as an architectural primitive in [The Orchestration Framework](https://github.com/Neo-The-Architect/The-Orchestration-Framework) so that other operators maintaining public-plus-private artifact boundaries can adopt the same discipline.
+
 ## What kinds of contribution are most welcome
 
 - **Documentation corrections.** Typos, broken links, factual errors in runbooks or ADRs, clarifications where the prose is ambiguous. These are the highest-leverage contributions for a public-build repo.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,10 @@ The repo is a public artifact and the operator wants the security disclosure pro
 
 The "TBD email" placeholder is itself an honest signal: the policy is real, the GitHub channel is fully operational, and the email channel is on a known finite list of things to provision before the first paying client. That is preferable to fabricating an email that goes nowhere.
 
+## Related: operational discipline against unintentional disclosure
+
+Vulnerability disclosure is one half of the disclosure surface this document governs. The other half is operational discipline: the day-to-day rules that prevent the operator's private context from leaking into public artifacts through ordinary contribution work. The anonymization protocol — including the locked verification language for anonymization grep checks and the close-and-reopen procedure for force-push correction — is documented under [`CONTRIBUTING.md`](CONTRIBUTING.md). It is referenced here so that anyone evaluating the security posture of this repository sees both halves of the disclosure surface in one map.
+
 ## Updates
 
 This document is versioned through git like every other artifact in the repo. Material changes (the addition of an email address, a change to response times, a change to scope) land through PRs reviewed by the operator. Stylistic edits and link updates may land without ceremony.


### PR DESCRIPTION
## Summary

Codifies the discipline rule that prevents the operator's canonical private-brand exclusion list from appearing in any public-facing content (PR bodies, commit messages, issue bodies, file contents, ADR text, runbook text, README content, CHANGELOG entries). The list itself lives privately in the operator's vault and is never published.

This PR is sequenced **before** PR #14 (Foundation Document v1.2) so the discipline is documented in the canonical version of the contributing guide at the moment v1.2 lands.

### What this PR adds

- **CONTRIBUTING.md** — new top-level section "Anonymization protocol for public artifacts" placed between "How to submit a pull request" and "What kinds of contribution are most welcome." Defines the boundary, locks the verification language for anonymization grep checks to one exact phrasing, requires that grep output containing matched strings is never echoed into committed content, and documents the corrective procedures (force-push correction, close-and-reopen, main-leak escalation).
- **SECURITY.md** — small cross-reference section "Related: operational discipline against unintentional disclosure" placed before "Updates." Points to CONTRIBUTING.md so anyone evaluating the security posture sees both halves of the disclosure surface in one map.

### Why now

This protocol was triggered by a real discipline failure during the Foundation Document v1.2 work block (PR #13, closed and reopened as PR #14). The verification *language* leaked exactly what the verification was meant to protect. Force-push correction landed the immediate fix; this PR makes the rule durable infrastructure instead of in-session memory.

The protocol is also referenced in the upcoming Orchestration Framework v0.2 PR as a published architectural primitive, framed as a methodology gift other operators can adopt.

## Test plan

- [ ] Diff reviewed end-to-end (CONTRIBUTING.md new section reads cleanly; SECURITY.md cross-reference is appropriately small)
- [ ] Locked verification language matches the exact phrasing used in PR #14's body and commit message
- [ ] Cross-reference link from SECURITY.md to CONTRIBUTING.md resolves
- [ ] Cross-reference link from CONTRIBUTING.md to The Orchestration Framework resolves
- [ ] Anonymization grep clean — verified zero matches against canonical private-brand exclusion list at commit time. Operator maintains the canonical list privately.
- [ ] No broken markdown
- [ ] Sequencing: this PR merges before PR #14 so canonical Foundation Document ships into a repo where the discipline is already documented