### PR TITLE
feat(systemd): commit restate service template

### DIFF
--- a/infra/systemd/restate.service.template
+++ b/infra/systemd/restate.service.template
@@ -1,0 +1,74 @@
+# Restate systemd service unit — canonical template
+#
+# This file is the canonical source of truth for the Restate systemd unit.
+# The deploy flow is:
+#
+#     sudo install -o root -g root -m 0644 \
+#         infra/systemd/restate.service.template \
+#         /etc/systemd/system/restate.service
+#
+# Do NOT edit /etc/systemd/system/restate.service in place on the host. Edits
+# diverge from this template silently. If a change is needed, edit this file,
+# commit, redeploy.
+#
+# Canonical reference: infra/runbooks/install-restate.md, "Materialize the
+# systemd unit" step. Audit item 26.
+#
+# Placeholders the operator must fill in before enabling the corresponding
+# behavior:
+#   <ALERT_SERVICE_UNIT> — the systemd unit name for the operator's chosen
+#                          alert path (Discord webhook, email, SMS, etc.).
+#                          Only required if OnFailure= is uncommented.
+#                          Wire as: OnFailure=<ALERT_SERVICE_UNIT>.service
+#
+# Everything else in this template uses the canonical defaults documented in
+# the runbook (user/group restate, binary path /usr/local/bin/restate-server,
+# config path /etc/restate/restate.toml, data path /var/lib/restate, log path
+# /var/log/restate). Operators forking this repo who deviate from those
+# defaults must update both this template and the runbook in the same PR.
+
+[Unit]
+Description=Restate durable executor (Weft substrate)
+Documentation=https://docs.restate.dev/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=restate
+Group=restate
+ExecStart=/usr/local/bin/restate-server --config-file /etc/restate/restate.toml
+
+# Logs to journald — accessible via `journalctl -u restate`.
+StandardOutput=journal
+StandardError=journal
+
+# Restart-on-failure with bounded backoff. The architecture demands restart
+# behavior — Restate down means Weft executions stall.
+Restart=always
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=10
+
+# OnFailure hook fires after the StartLimit window is exhausted. Wire this
+# to whatever the operator alert path is (Discord webhook unit, email, etc.).
+# OnFailure=<ALERT_SERVICE_UNIT>.service
+
+# Sandboxing: read-only system, write-only into the data and log dirs.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+ReadWritePaths=/var/lib/restate /var/log/restate
+LockPersonality=true
+
+# Environment overrides go here if needed (env file lives outside repo).
+# EnvironmentFile=-/etc/restate/restate.env
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Extracts the Restate systemd service unit body from [\`infra/runbooks/install-restate.md\`](infra/runbooks/install-restate.md) ("Materialize the systemd unit" step) into [\`infra/systemd/restate.service.template\`](infra/systemd/restate.service.template) as canonical source of truth.

Closes the first half of the source-of-truth inversion flagged in the Phase D audit (item 26): the repo, not the live host, is canonical for the unit. Audit item 12 — rewriting the runbook to install from this template rather than \`cp\`-ing from the deployed host — is a separate Phase E PR.

Resolves #16.

## What landed

- New file \`infra/systemd/restate.service.template\` containing:
  - Header comment block naming the file's role, the deploy flow (install from repo, never edit on host), the canonical runbook reference, and placeholder semantics.
  - The full unit body extracted verbatim from the runbook.
  - One placeholder: \`<ALERT_SERVICE_UNIT>\` inside the commented-out \`OnFailure=\` line. The runbook explicitly names this as operator-chosen (Discord webhook, email, SMS, etc.) rather than canonical, so it gets placeholder syntax. All other values stay canonical.

## What did NOT land in this PR

- The runbook rewrite (\`docs(runbook): rewrite restate template deployment flow\` — audit item 12). Per Phase E sequencing, that depends on this PR and lands next.
- Removal of the \`.gitkeep\` from \`infra/systemd/\`. Dead weight now that the directory has real content, but bundling that fix would expand scope. Held for a follow-up cleanup PR.

## Test plan

- [ ] Diff reviewed — header comment block reads cleanly; unit body matches what is in the runbook today
- [ ] Placeholder syntax \`<ALERT_SERVICE_UNIT>\` only appears in the commented-out \`OnFailure=\` line; everything else uses canonical defaults
- [ ] No surprise edits outside \`infra/systemd/restate.service.template\`
- [ ] Anonymization grep clean — verified zero matches against canonical private-brand exclusion list at commit time. Operator maintains the canonical list privately.
- [ ] No broken markdown
- [ ] Single commit, single concern