### PR TITLE
docs(runbook): rewrite restate template deployment flow

### DIFF
--- a/infra/runbooks/install-restate.md
+++ b/infra/runbooks/install-restate.md
@@ -139,65 +139,30 @@ Schema drift across Restate versions is a real risk (see `## Concerns`). Validat
 
 If a key in the config file is unknown to the binary, Restate either logs a warning and ignores it (older versions) or refuses to start (newer versions). Either way, you find out at step 6.
 
-### 5. Materialize the systemd unit
+### 5. Materialize the systemd unit from `infra/systemd/restate.service.template`
 
-Write `/etc/systemd/system/restate.service`:
+The canonical Restate systemd unit lives in this repo at [`infra/systemd/restate.service.template`](../systemd/restate.service.template). It is a deploy-ready unit: sandboxed (`ProtectSystem=strict`, `NoNewPrivileges`, constrained `ReadWritePaths`), journald logging, restart-on-failure with bounded backoff, run as `restate:restate`, exec'ing `/usr/local/bin/restate-server --config-file /etc/restate/restate.toml`. The runbook does not duplicate the unit body — read the template if you want every directive in full. The runbook is canonical for *how* the unit is deployed; the template is canonical for *what* the unit is.
 
-```ini
-[Unit]
-Description=Restate durable executor (Weft substrate)
-Documentation=https://docs.restate.dev/
-After=network-online.target
-Wants=network-online.target
+Before installing, decide on OnFailure alert wiring. The template ships with the `OnFailure=` line commented out. If you want failures to page an alert path (Discord webhook unit, email-relay unit, etc.), edit the template's `# OnFailure=<ALERT_SERVICE_UNIT>.service` line — replace `<ALERT_SERVICE_UNIT>` with your alert service unit's name and uncomment. Commit the change before installing; the install step copies whatever is committed.
 
-[Service]
-Type=simple
-User=restate
-Group=restate
-ExecStart=/usr/local/bin/restate-server --config-file /etc/restate/restate.toml
-
-# Logs to journald — accessible via `journalctl -u restate`.
-StandardOutput=journal
-StandardError=journal
-
-# Restart-on-failure with bounded backoff. The architecture demands restart
-# behavior — Restate down means Weft executions stall.
-Restart=always
-RestartSec=5
-StartLimitIntervalSec=60
-StartLimitBurst=10
-
-# OnFailure hook fires after the StartLimit window is exhausted. Wire this
-# to whatever the operator alert path is (Discord webhook unit, email, etc.).
-# OnFailure=restate-failure-alert.service
-
-# Sandboxing: read-only system, write-only into the data and log dirs.
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=true
-PrivateTmp=true
-PrivateDevices=true
-ProtectKernelTunables=true
-ProtectKernelModules=true
-ProtectControlGroups=true
-RestrictSUIDSGID=true
-ReadWritePaths=/var/lib/restate /var/log/restate
-LockPersonality=true
-
-# Environment overrides go here if needed (env file lives outside repo).
-# EnvironmentFile=-/etc/restate/restate.env
-
-[Install]
-WantedBy=multi-user.target
-```
-
-Mirror this unit into `infra/systemd/restate.service.template` so the artifact lives in the repo:
+Install the template into systemd. Run from the repo root:
 
 ```bash
-sudo cp /etc/systemd/system/restate.service \
-    /home/<OPERATOR>/workspace/efficient-labs/infra/systemd/restate.service.template
-# Then commit the template (no secrets in it).
+sudo install -o root -g root -m 0644 \
+    infra/systemd/restate.service.template \
+    /etc/systemd/system/restate.service
 ```
+
+The `install` form (rather than `cp`) is deliberate — it sets the canonical owner, group, and mode in one call.
+
+Verify the deployed unit matches the template byte-for-byte:
+
+```bash
+sudo diff infra/systemd/restate.service.template /etc/systemd/system/restate.service
+# expect: no output (files identical)
+```
+
+**Discipline:** any subsequent edit to the unit happens in the template, gets committed, then redeployed via the same `install` command above. Never edit `/etc/systemd/system/restate.service` directly on the host — host-side edits diverge silently from the committed template, and the next redeploy overwrites them without warning.
 
 ### 6. Enable and start Restate
 


### PR DESCRIPTION
## Summary

Inverts the source-of-truth posture in [\`install-restate.md\`](infra/runbooks/install-restate.md) step 5: the runbook now installs the systemd unit FROM [\`infra/systemd/restate.service.template\`](infra/systemd/restate.service.template) TO \`/etc/systemd/system/restate.service\`, instead of inlining the unit body in the runbook and then \`cp\`-ing the deployed file back into the repo.

This is the second half of the audit item 26 + 12 pair. PR #17 added the canonical template; this PR makes the runbook agree.

Resolves #18.

## Specific changes to step 5

- **Heading expanded** to "Materialize the systemd unit from \`infra/systemd/restate.service.template\`" — matches the verb-form already used in [\`install-weft-and-paperclip.md\`](infra/runbooks/install-weft-and-paperclip.md) so all three runbooks read consistently.
- **Inline unit body removed.** Replaced with one paragraph naming the canonical template, linking to it, and summarizing what the unit provides at a high level (sandboxing posture, restart behavior, journald logging, run as \`restate:restate\`, exec'ing the pinned binary). A reader gets the mental model without context-switching; the template is the source of every individual directive.
- **New paragraph documents the \`<ALERT_SERVICE_UNIT>\` placeholder semantics** — the operator decides whether to wire OnFailure alerts before deploy and edits the *template* (committed) rather than the deployed unit. Default is no OnFailure wiring.
- **The \`cp\`-from-host step is gone.** Replaced with the canonical install form prescribed by the Phase D audit (line 112): \`sudo install -o root -g root -m 0644\` from the template path to \`/etc/systemd/system/restate.service\`, run from the repo root.
- **New verification step** uses \`sudo diff\` to confirm the deployed unit matches the committed template byte-for-byte.
- **Discipline note** appended: edits happen in the template, get committed, then redeploy. Never edit the host-side file in place.

No other sections touched. Step 6 (Enable and start) picks up cleanly from the rewritten step 5.

## Diff size

15 insertions, 50 deletions — net 35 lines removed. The runbook gets shorter because the unit body no longer lives in two places.

## Test plan

- [ ] Diff reviewed — heading expanded; inline unit body removed; install command matches the audit-prescribed form
- [ ] Link to template resolves
- [ ] Cross-runbook consistency: step 5 verb-form matches what install-weft-and-paperclip.md already uses for its systemd templates
- [ ] \`<ALERT_SERVICE_UNIT>\` placeholder semantics documented
- [ ] Edit-the-template-not-the-host caveat present
- [ ] No edits outside step 5
- [ ] Anonymization grep clean — verified zero matches against canonical private-brand exclusion list at commit time. Operator maintains the canonical list privately.
- [ ] No broken markdown
- [ ] Single commit, single concern