### PR TITLE
docs(runbook): tailscale serve deploy-time verification note

### DIFF
--- a/infra/runbooks/install-restate.md
+++ b/infra/runbooks/install-restate.md
@@ -183,6 +183,15 @@ If status shows anything other than `active (running)` and the journal does not 
 
 The admin API is loopback-only. Operator access is via Tailscale Serve, **never Tailscale Funnel** — Funnel exposes to the public internet, which is not what we want for the admin surface.
 
+**Deploy-time verification first.** The Tailscale Serve CLI has gone through revisions across releases; the invocation below is the most-likely-correct form as of the runbook's commit date but specific flag names and subcommand placement may have shifted. Before running it, capture the installed version and confirm the flag form against the live help output:
+
+```bash
+tailscale --version                              # capture in operator deploy log
+tailscale serve --help 2>&1 | head -40           # confirm --bg and --https=<port> exist on this version
+```
+
+Then run the canonical invocation:
+
 ```bash
 # Run as the user/scope that owns the Tailscale node.
 sudo tailscale serve --bg --https=9070 http://127.0.0.1:9070
@@ -192,6 +201,8 @@ sudo tailscale serve --bg --https=9070 http://127.0.0.1:9070
 #   curl https://<vps-tailscale-name>.tailnet.ts.net:9070/...
 # (Substitute the tailnet hostname for your tailnet.)
 ```
+
+If the canonical invocation errors — flags renamed, deprecated, or moved between subcommands — find the working form via `tailscale serve --help`, `tailscale serve status`, or the [Tailscale Serve docs](https://tailscale.com/kb/1242/tailscale-serve). Run the working form, capture it in the operator deploy log, and file a runbook-fix issue against this repo so the next operator (or future-self) does not hit the same drift.
 
 Document the exact Tailscale Serve mapping in your operator's tailnet notes — Tailscale's ACL state is not version-controlled here on purpose.
 


### PR DESCRIPTION
## Summary

Adds a deploy-time verification block to step 7 of [\`install-restate.md\`](infra/runbooks/install-restate.md) ("Tailscale Serve mapping for operator-only admin access"). The Tailscale Serve CLI has gone through revisions across releases; the canonical invocation documented in the runbook is the most-likely-correct form, but specific flag names and subcommand placement may drift. The runbook now flags this honestly and instructs the operator to verify before running.

Resolves #20.

## Specific changes to step 7

- **New paragraph** names the CLI revision risk and instructs deploy-time verification before running the canonical invocation.
- **New bash block** with two commands: \`tailscale --version\` (capture in operator deploy log) and \`tailscale serve --help 2>&1 | head -40\` (confirm \`--bg\` and \`--https=<port>\` exist on the installed version).
- **Existing canonical invocation block** kept verbatim, now framed as the step that runs after verification.
- **New paragraph** names the corrective path if the canonical invocation errors: find the working form via help output or the [Tailscale Serve docs](https://tailscale.com/kb/1242/tailscale-serve), run it, capture in deploy log, file a runbook-fix issue.

No edits outside step 7. The canonical invocation itself is unchanged — the audit's fix is to document the verification, not to pre-decide the working form. The working form is the deploy-time decision.

## Diff size

11 insertions, 0 deletions.

## Test plan

- [ ] Diff reviewed — verification paragraph and bash block placed before the canonical invocation; corrective-path paragraph placed after
- [ ] Canonical invocation kept verbatim
- [ ] Tailscale docs link resolves
- [ ] No edits outside step 7
- [ ] Anonymization grep clean — verified zero matches against canonical private-brand exclusion list at commit time. Operator maintains the canonical list privately.
- [ ] No broken markdown
- [ ] Single commit, single concern