### PR TITLE
chore(hooks): install anonymization gate via core.hooksPath

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,42 @@
+# Repo hooks — anonymization gate
+
+Git hooks that enforce the public-repo anonymization protocol from Foundation
+Document v1.2 Section 4.5 / Section 15. Two hooks:
+
+- `pre-commit` scans staged content against the operator's canonical denylist
+  at `/home/neo/vault/anonymization-denylist.txt`. Fails closed if unreadable.
+- `commit-msg` requires the locked verification line in every commit message.
+
+## Activate in this clone
+
+```sh
+git config core.hooksPath .githooks
+```
+
+`pre-commit` framework users (`pip install pre-commit && pre-commit install`)
+get the same logic via `.pre-commit-config.yaml` at the repo root.
+
+## Operator setup (one-time, after creating the denylist)
+
+Grant the `claude` user read-only access to the denylist without exposing the
+rest of the vault:
+
+```sh
+sudo setfacl -m u:claude:--x /home/neo
+sudo setfacl -m u:claude:--x /home/neo/vault
+sudo setfacl -m u:claude:r-- /home/neo/vault/anonymization-denylist.txt
+```
+
+## Local testing
+
+Override the denylist path with a fixture file:
+
+```sh
+DENYLIST_PATH=/tmp/test-denylist.txt git commit ...
+```
+
+## Bypass for non-content commits
+
+Merge, revert, fixup, and squash commits skip both hooks automatically. For
+unusual cases, set `ANONYMIZATION_VERIFY_SKIP=1` on the `git commit` invocation.
+Use sparingly — the audit trail benefits from uniform attestation.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verification-language gate for public-repo commits.
+#
+# Per Foundation Document v1.2 anonymization protocol: every public-repo commit
+# message must contain the locked verification line. The exact wording is mandated
+# so that public commits carry uniform attestation that the anonymization grep
+# was run, without exposing the operator's canonical exclusion list.
+#
+# To bypass for non-content commits (merges, reverts), set:
+#   ANONYMIZATION_VERIFY_SKIP=1 git commit ...
+# Use sparingly; the audit trail benefits from uniform attestation.
+
+set -euo pipefail
+
+MSG_FILE="$1"
+LOCKED_LINE='Anonymization grep clean — verified zero matches against canonical private-brand exclusion list at commit time. Operator maintains the canonical list privately.'
+
+err() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+
+# Skip merge commits, reverts, and fixups — they inherit attestation from the
+# commits they reference.
+first_line=$(head -n 1 "$MSG_FILE")
+case "$first_line" in
+  Merge\ *|Revert\ *|fixup!*|squash!*) exit 0 ;;
+esac
+
+if [[ "${ANONYMIZATION_VERIFY_SKIP:-0}" == "1" ]]; then
+  exit 0
+fi
+
+if ! grep -qF -- "$LOCKED_LINE" "$MSG_FILE"; then
+  err "anonymization gate: commit message missing verification line"
+  err ""
+  err "  required line (exact wording, including em-dash):"
+  err "  $LOCKED_LINE"
+  err ""
+  err "  append it to your commit message and retry"
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Anonymization gate for public-repo commits.
+#
+# Reads a denylist of canonical private-brand strings (one per line, # for
+# comments) from $DENYLIST_PATH (default /home/neo/vault/anonymization-denylist.txt)
+# and refuses any commit whose staged diff matches any of those strings.
+#
+# Fails closed: if the denylist is unreadable, the commit is blocked.
+#
+# To set up read access for the claude user against an operator-private denylist:
+#   sudo setfacl -m u:claude:--x /home/neo
+#   sudo setfacl -m u:claude:--x /home/neo/vault
+#   sudo setfacl -m u:claude:r-- /home/neo/vault/anonymization-denylist.txt
+#
+# To override the denylist path (e.g. for local testing):
+#   DENYLIST_PATH=/tmp/mock-denylist.txt git commit ...
+
+set -euo pipefail
+
+DENYLIST_PATH="${DENYLIST_PATH:-/home/neo/vault/anonymization-denylist.txt}"
+
+err() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+info() { printf '%s\n' "$*" >&2; }
+
+if [[ ! -r "$DENYLIST_PATH" ]]; then
+  err "anonymization gate: denylist not readable at $DENYLIST_PATH"
+  err "  - file may not exist yet, or current user lacks read access"
+  err "  - if operator-private vault file: see header of this script for setfacl commands"
+  err "  - to override path for local testing: DENYLIST_PATH=/path/to/denylist git commit ..."
+  exit 1
+fi
+
+# Build pattern list from denylist: skip blanks and # comments, trim trailing whitespace.
+mapfile -t PATTERNS < <(
+  sed -E 's/[[:space:]]+$//' "$DENYLIST_PATH" \
+    | grep -Ev '^[[:space:]]*$|^[[:space:]]*#'
+)
+
+if [[ ${#PATTERNS[@]} -eq 0 ]]; then
+  info "anonymization gate: denylist is empty (no patterns to enforce); allowing commit"
+  exit 0
+fi
+
+# Collect staged files. Skip deletions, binary blobs are still scanned via diff.
+mapfile -t STAGED < <(git diff --cached --name-only --diff-filter=ACMRT)
+
+if [[ ${#STAGED[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+violations=0
+report=()
+
+# Scan the staged diff (added lines only) against each pattern.
+# Using --cached --no-color and processing per-file gives clean reporting.
+for f in "${STAGED[@]}"; do
+  # Skip the denylist itself in case it ever lands inside the repo by accident.
+  [[ "$f" == ".githooks/"* ]] && continue
+  # Pull the staged version of the file; ignore if missing (e.g. submodule).
+  staged_blob=$(git show ":$f" 2>/dev/null) || continue
+  for pattern in "${PATTERNS[@]}"; do
+    # Fixed-string, case-insensitive match. Avoids regex foot-guns in operator-edited list.
+    if matches=$(printf '%s' "$staged_blob" | grep -nFi -- "$pattern" 2>/dev/null); then
+      while IFS= read -r line; do
+        report+=("$f: $line")
+        violations=$((violations + 1))
+      done <<< "$matches"
+    fi
+  done
+done
+
+if [[ $violations -gt 0 ]]; then
+  err "anonymization gate: BLOCKED — $violations match(es) against denylist"
+  err ""
+  for r in "${report[@]}"; do
+    err "  $r"
+  done
+  err ""
+  err "  remove the offending content or move it to a private repo before committing"
+  exit 1
+fi
+
+info "anonymization gate: clean ($(wc -l < "$DENYLIST_PATH") denylist entries scanned across ${#STAGED[@]} staged file(s))"
+exit 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# pre-commit framework configuration. Wraps the native scripts in .githooks/
+# so the same scanning logic runs whether contributors use `pre-commit install`
+# or `git config core.hooksPath .githooks`.
+#
+# To activate after `pip install pre-commit`:
+#   pre-commit install --hook-type pre-commit --hook-type commit-msg
+
+repos:
+  - repo: local
+    hooks:
+      - id: anonymization-grep
+        name: anonymization gate (denylist scan)
+        entry: .githooks/pre-commit
+        language: script
+        stages: [pre-commit]
+        pass_filenames: false
+        always_run: true
+      - id: anonymization-verification-line
+        name: anonymization gate (verification line)
+        entry: .githooks/commit-msg
+        language: script
+        stages: [commit-msg]


### PR DESCRIPTION
## Summary
- Adds `pre-commit` and `commit-msg` git hooks enforcing the public-repo anonymization protocol per Foundation Document v1.2 §4.5/§15
- Hooks live in `.githooks/` and activate via `git config core.hooksPath .githooks` (no external dependencies)
- `pre-commit` framework path remains compatible via `.pre-commit-config.yaml`

## What ships
- `.githooks/pre-commit` — denylist scanner; fail-closed if denylist unreadable; fixed-string case-insensitive match; auto-skips files inside `.githooks/`
- `.githooks/commit-msg` — requires the locked verification line (exact em-dash); auto-skips merge/revert/fixup commits; honors `ANONYMIZATION_VERIFY_SKIP=1` escape hatch
- `.githooks/README.md` — operator setup recipe (incl. ACL grant for cross-user denylist read) and override guidance for local testing
- `.pre-commit-config.yaml` — wraps the same scripts as `local` hooks under the framework path

## Activate in a fresh clone
```sh
git config core.hooksPath .githooks
```

## Test plan
- [x] Empty/comment-only denylist: hooks shortcircuit with "no patterns to enforce", commit allowed
- [x] Populated denylist, clean staged content: scanner reports "N entries scanned across M file(s)", commit allowed
- [x] Populated denylist, staged content matches a pattern: scanner reports "BLOCKED — N match(es)", commit blocked (exit 1)
- [x] Missing verification line in commit message: blocked with exact-line guidance
- [x] Wrong-dash typo (hyphen vs em-dash): blocked
- [x] Merge / fixup / revert commits: auto-skip both hooks
- [x] `ANONYMIZATION_VERIFY_SKIP=1`: bypasses commit-msg gate (sparingly)