### PR TITLE
docs: three-repo reference + update Orchestral URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ The canonical design document for the whole system lives at [`docs/architecture/
 
 ## Operating Methodology
 
-Efficient Labs operates within [The Orchestration Framework](https://github.com/Neo-The-Architect/The-Orchestration-Framework) — a public methodology that defines how a single human operator commands an agentic stack of AI tools through structured files. The framework specifies philosophical foundations, vault file architecture, agentic stack roles, operating rhythms, trigger words, and recurring failure modes.
+Efficient Labs operates within [The Orchestration Framework](https://github.com/Neo-The-Architect/Orchestral) — a public methodology that defines how a single human operator commands an agentic stack of AI tools through structured files. The framework specifies philosophical foundations, vault file architecture, agentic stack roles, operating rhythms, trigger words, and recurring failure modes.
 
 The engineering discipline visible in this repo (Architecture Decision Records, runbooks, infrastructure audits, public commit attribution to AI agents) instantiates the framework. The methodology evolves independently at its own repo and may be adopted by other operators.
+
+Efficient Labs applies the Orchestral methodology to client engagements. Three-repo architecture:
+
+- **Solo-AI** (private) — Sovereign Orchestration Layer Ontology
+- **Orchestral** (public) — Open methodology
+- **Efficient-Labs** (this repo, public) — Commercial trust layer
 
 See [ADR 0006](docs/adr/0006-orchestration-framework-as-operating-methodology.md) for the formal decision establishing this relationship.
 


### PR DESCRIPTION
## Summary

- Updates README.md \"Operating Methodology\" section to reference the renamed Orchestral repo
- URL change: `The-Orchestration-Framework` → `Orchestral` (repo rename only; methodology brand unchanged)
- Adds a brief three-repo architecture paragraph positioning Efficient-Labs as the commercial trust layer applying Orchestral methodology, with Solo-AI as the private upstream

## Test plan

- [x] Anonymization gate clean (10 denylist entries × 1 file)
- [x] Commit-msg gate clean (locked attestation line present)
- [x] No other `The-Orchestration-Framework` occurrences in README
- [ ] Operator review: framing reads correctly, link target valid, ADR 0006 reference still accurate
- [ ] Merge if approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)