### PR TITLE
docs(process): add incident readiness stubs

### DIFF
--- a/docs/operators/README.md
+++ b/docs/operators/README.md
@@ -7,6 +7,7 @@ This directory holds documents written for the operator's own benefit — refere
 | Document | Purpose |
 | --- | --- |
 | [Command reference](command-reference.md) | Cold-start command reference. The first document opened when returning after a break. Covers VPS access, sandbox launch, two-user discipline, common operations, emergency recovery, auth inventory, key URLs. **Living document, draft v1 from workspace context** — will be augmented from the operator's external canonical reference in a follow-up commit. |
+| [Vendor escalation](vendor-escalation.md) | Pre-client vendor escalation stub. Names the vendor classes and evidence to capture before escalating, without publishing private account contacts. |
 | [Onboarding](onboarding.md) | Onboarding document for a future operator (or future-Neo after a long break). **Stub.** Substance lands when the first second-operator joins or when the operator returns from a break long enough to test the document against their own memory. |
 
 ## What lives here vs. elsewhere
@@ -16,7 +17,7 @@ This directory holds documents written for the operator's own benefit — refere
 - **Processes:** in [`docs/processes/`](../processes/). Processes describe how the team operates (review cycle, incident response, runbook authoring discipline).
 - **ADRs:** in [`docs/adr/`](../adr/). Decisions that constrain subsequent work.
 - **Architecture report:** in [`docs/architecture/`](../architecture/). The canonical design document.
-- **Vendor escalation contacts:** not yet on disk; tracked as a gap in [`docs/processes/incident-response.md`](../processes/incident-response.md) under "open questions."
+- **Vendor escalation:** [`vendor-escalation.md`](vendor-escalation.md). Public-safe stub for escalation evidence and vendor classes; private account contacts stay out of git.
 
 ## How to add an operator document
 

--- a/docs/operators/vendor-escalation.md
+++ b/docs/operators/vendor-escalation.md
@@ -1,0 +1,66 @@
+# Vendor escalation
+
+**Status:** Pre-client stub. This document names the vendor escalation shape before the first paying client, without publishing private account contacts, support portal credentials, contract IDs, or emergency phone numbers.
+
+The goal is to make incident triage faster without pretending Efficient Labs has enterprise support relationships that do not exist yet.
+
+## When to use this document
+
+Use this document when an incident appears to depend on a vendor system Efficient Labs does not operate directly. Examples:
+
+- VPS or network provider outage;
+- Tailscale access or mesh connectivity issue;
+- GitHub availability or repository-access issue;
+- AI provider capacity, authentication, or API degradation;
+- Stripe checkout, billing, or webhook delivery issue;
+- Cloudflare Pages, DNS, or edge-routing issue after the public launch surface exists.
+
+If the issue is inside code, configuration, or infrastructure Efficient Labs operates directly, start with [`../processes/incident-response.md`](../processes/incident-response.md) instead.
+
+## Escalation checklist
+
+Before opening a vendor ticket, capture the smallest useful evidence packet:
+
+1. UTC timestamp and local timestamp.
+2. Impact summary: what is broken, who is affected, and whether any client-facing surface is degraded.
+3. Last known-good time.
+4. Recent Efficient Labs changes that could plausibly explain the issue.
+5. Vendor status-page result or public incident link, if one exists.
+6. Sanitized error output: no tokens, no customer data, no private host identifiers unless the vendor needs the identifier inside its private support portal.
+7. Current containment decision: wait, retry later, fail over, pause work, or rollback.
+
+## Vendor classes
+
+| Vendor class | Examples | First check | Escalation path |
+| --- | --- | --- | --- |
+| VPS / host | Hostinger or current VPS provider | Provider status page, VPS console, host reachability from Tailscale and public network | Provider support portal; private account identifiers stay outside git |
+| Mesh access | Tailscale | Tailscale admin console, device status, ACL changes, existing-session behavior | Tailscale support if access is broadly degraded |
+| Source control | GitHub | GitHub status, local `git status`, branch protection, token scope | GitHub support or repository security advisory flow as appropriate |
+| AI providers | Anthropic, OpenAI, Google Gemini | Provider status, CLI/API auth probe, quota/capacity error classification | Provider support/docs; capacity errors are tracked as degraded dependency, not operator auth failure |
+| Payments | Stripe | Stripe dashboard, webhook delivery log, checkout-session state | Stripe support; preserve event IDs privately |
+| Edge / site | Cloudflare Pages or chosen host | Deployment status, DNS, edge logs, public URL check | Provider support after ruling out local deployment error |
+
+## What must not be committed
+
+- Account IDs, invoice IDs, contract IDs, support-ticket private URLs, or emergency phone numbers.
+- API keys, OAuth tokens, webhook signing secrets, or session cookies.
+- Client names, client data, or prospect data.
+- Raw terminal transcripts that include hostnames, IP addresses, or private paths.
+
+Private vendor details belong in the operator's password manager or private vault. This public document only stores the escalation shape.
+
+## Before first paying client
+
+Complete these items before a client-facing SLA depends on the stack:
+
+- Confirm the active support path for the VPS provider.
+- Confirm the active support path for Stripe before taking payment.
+- Confirm where AI-provider quota/capacity incidents are logged internally.
+- Decide whether Cloudflare Pages, Vercel, or another host owns the public trust-layer deployment.
+- Add a private operator note, outside this repo, with account-specific support links.
+
+## Relationship to incident response
+
+[`../processes/incident-response.md`](../processes/incident-response.md) decides whether something is an incident and how to triage it. This document answers one narrower question: if the cause is likely a vendor, what evidence should the operator collect and where does the escalation live?
+
+Every vendor escalation that affects a client-facing surface should leave a one-line entry in [`../processes/incident-log.md`](../processes/incident-log.md). If the incident meets the postmortem threshold, the postmortem records the vendor timeline and whether the escalation path worked.

--- a/docs/processes/README.md
+++ b/docs/processes/README.md
@@ -11,6 +11,7 @@ Process documents are durable. They evolve when the underlying practice evolves;
 | [Runbook execution protocol](runbook-execution-protocol.md) | The discipline for authoring, executing, and verifying runbooks. Single-command discipline, two-window pattern, stop on error, DRAFT → VERIFIED status flow. |
 | [Issue-to-fix pattern](issue-to-fix-pattern.md) | The PRD-driven workflow used to delegate substantive engineering work to Claude Code in sandbox, with operator review through the PR chain. |
 | [Incident response](incident-response.md) | Triage checklist, escalation criteria, and postmortem trigger threshold. Stub today; fills out substantively after first real incident. |
+| [Incident log](incident-log.md) | Public-safe incident index. Starts empty; client-impacting or security-relevant events get one-line entries. |
 | [Postmortem template](postmortem-template.md) | Blameless postmortem template. Sections for summary, timeline, root cause, impact, what went well, what went poorly, action items, lessons. |
 | [Code review checklist](code-review-checklist.md) | Self-review checklist for the solo+AI workflow. Honest about the constraint (one human reviewer, AI executor). Applied by the operator before merge and by the executor before opening the PR. |
 | [Branch protection](branch-protection.md) | Spec for the GitHub branch-protection settings on `main`. Documents enabled rules and aspired rules with the asymmetries (signed commits, required reviews) explained. |

--- a/docs/processes/incident-log.md
+++ b/docs/processes/incident-log.md
@@ -1,0 +1,36 @@
+# Incident log
+
+**Status:** Empty pre-client log. Efficient Labs has no public client-impacting incidents recorded in this repository as of this document's creation.
+
+This file is the public-safe index of incidents and near-misses that matter to the operating discipline. It is intentionally concise. Detailed investigation belongs in a postmortem linked from the log entry.
+
+## Entry format
+
+Use one line per incident:
+
+| Date | Severity | Surface | Symptom | Resolution | Postmortem |
+| --- | --- | --- | --- | --- | --- |
+| _No incidents recorded yet._ |  |  |  |  |
+
+## What gets logged here
+
+Log an event here when any of the following is true:
+
+- a client-facing service is degraded or unavailable;
+- a security-relevant event is suspected or confirmed;
+- a backup, deploy, access path, payment path, or public trust surface fails in a way that requires operator intervention;
+- a vendor outage materially affects fulfillment;
+- the operator decides the near-miss has enough learning value to preserve.
+
+## What does not get logged here
+
+- Raw credentials, tokens, session identifiers, private support URLs, client data, or prospect data.
+- Full terminal transcripts.
+- Private hostnames, public IP addresses, or internal file paths unless already disclosed elsewhere intentionally.
+- Routine retries that self-heal without operator action.
+
+## Relationship to postmortems
+
+The trigger threshold for a full postmortem lives in [`incident-response.md`](incident-response.md). If an event does not meet that threshold, this log entry can be the entire record.
+
+If an event does meet the threshold, create a postmortem from [`postmortem-template.md`](postmortem-template.md), then link it in the `Postmortem` column.

--- a/docs/processes/incident-response.md
+++ b/docs/processes/incident-response.md
@@ -18,7 +18,7 @@ Routine alerts (a brief retry burst, a slow query) are not incidents. The bounda
 
 When an incident is identified, the operator runs the following checklist in order. The checklist is short on purpose — long checklists are skipped under stress.
 
-1. **Capture the time and the symptom.** A one-line note in the incident log (TBD: where the log lives — see open question below). Timestamp matters for the postmortem timeline.
+1. **Capture the time and the symptom.** A one-line note in [incident-log.md](incident-log.md). Timestamp matters for the postmortem timeline.
 2. **Stop further changes.** Do not deploy, do not run runbooks, do not push commits to `main` until the incident is contained. The exception is a change that is part of the containment.
 3. **Read the most recent change history.** `git log -20` and the most recent merged PRs. Most production issues are caused by the most recent change; ruling that in or out is the cheapest first move.
 4. **Read the relevant logs.** `journalctl -u <service> --since '15 minutes ago'` for service-level incidents. Tailscale admin console for access incidents. `dmesg | tail` for host-level (OOM, disk-full, kernel) incidents.
@@ -51,9 +51,8 @@ The postmortem template is at [`postmortem-template.md`](postmortem-template.md)
 
 ## What is not in this document yet (open questions)
 
-- **Where the incident log lives.** Today there is no incident log because there have been no incidents. The log should be a single file in this repo (likely `docs/operations/incident-log.md`, not yet created) where each incident gets a one-line entry with timestamp, symptom, resolution, and a pointer to the postmortem if one was written. Land this file before the first paying client.
 - **Paging path.** Today the operator is the only responder and is reachable through the operator's primary devices (laptop, phone). Paging is not formalized. Once a second responder exists or once SLA commitments are made to clients, this section names the paging path explicitly.
-- **Vendor escalation contacts.** The list of who to contact at each vendor (Hostinger support, Tailscale support, Anthropic support, Stripe support) and the SLA each vendor offers. Not yet on disk; should be in `docs/operators/vendor-escalation.md` (not yet created) when this document is filled out.
+- **Vendor escalation account details.** The public-safe escalation shape now lives in [`../operators/vendor-escalation.md`](../operators/vendor-escalation.md). Private support portal links, account identifiers, emergency phone numbers, and contract-specific SLAs stay out of git and must be stored in the operator's private vault/password manager.
 - **Incident severity classification.** No formal SEV1/SEV2/SEV3 scheme yet. For a single-operator company without external SLAs, the binary "is this an incident" is sufficient; this document grows a severity scheme when the SLA structure of paying engagements requires one.
 - **Communication during incidents.** Today there are no clients to communicate with during an incident. When the first paying client is onboarded, the publish-policy template (in `legal/publish-policy-template.md`, when that lands) gates what is shared publicly during an incident. This document grows a section on client communication at that point.
 


### PR DESCRIPTION
## Summary
- add a public-safe vendor escalation stub for pre-client incident handling
- add an empty incident log and wire it into the process index
- update incident-response open questions now that the log and vendor escalation shape exist

## Verification
- .githooks/pre-commit
- git diff --cached --check

Anonymization grep clean — verified zero matches against canonical private-brand exclusion list at commit time. Operator maintains the canonical list privately.