### PR TITLE
feat(marketing-site): apply approved launch copy

### DIFF
--- a/marketing-site/src/layouts/BaseLayout.astro
+++ b/marketing-site/src/layouts/BaseLayout.astro
@@ -1,10 +1,17 @@
 ---
 import '../styles/global.css';
 
+const siteUrl = 'https://efficientlabs.ai';
 const {
   title = 'Efficient Labs',
-  description = 'Governed AI infrastructure for operators who refuse chaos.'
+  description = 'Governed AI infrastructure for operators who refuse chaos.',
+  canonicalPath = Astro.url.pathname,
+  robots = 'noindex, nofollow',
+  image = '/architecture-signal.svg'
 } = Astro.props;
+
+const canonicalUrl = new URL(canonicalPath, siteUrl).toString();
+const imageUrl = new URL(image, siteUrl).toString();
 ---
 <!doctype html>
 <html lang="en">
@@ -12,6 +19,18 @@ const {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    <meta name="robots" content={robots} />
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:site_name" content="Efficient Labs" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:image" content={imageUrl} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={imageUrl} />
     <title>{title}</title>
   </head>
   <body>

--- a/marketing-site/src/pages/audit.astro
+++ b/marketing-site/src/pages/audit.astro
@@ -4,28 +4,69 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="AI Sovereignty Audit | Efficient Labs">
   <section class="page-hero narrow">
     <h1>72-hour AI Sovereignty Audit.</h1>
-    <p>A practical review of automation risk, ownership boundaries, agent governance, and the next implementation steps for operators who need calm infrastructure.</p>
+    <p>A structured review of your automation risk, ownership boundaries, agent governance, and implementation gaps. Not consulting-speak. Findings you can act on this week.</p>
   </section>
+
+  <section class="section narrow">
+    <h2>Five areas. One deliverable.</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Pillar</th><th>What we assess</th></tr></thead>
+        <tbody>
+          <tr><td>Sovereignty</td><td>Who owns the output? Where does your data go? What happens when the vendor changes pricing?</td></tr>
+          <tr><td>Observability</td><td>Can you audit what your agents did last week? Can an external auditor?</td></tr>
+          <tr><td>Governance</td><td>Are there operator gates before the automation sends, charges, or publishes?</td></tr>
+          <tr><td>Secrets posture</td><td>Where are credentials stored? Who rotates them? What is the blast radius if one leaks?</td></tr>
+          <tr><td>Audit trail</td><td>Is there a tamper-evident record of what ran, when, and why?</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="section narrow">
+    <h2>Deliverable: findings report</h2>
+    <p>PDF findings report delivered within 72 business hours of intake completion.</p>
+    <ul class="check-list">
+      <li>Per-pillar findings: what we found, what it means, and the risk level.</li>
+      <li>Remediation priorities: top actions ordered by impact and effort.</li>
+      <li>Implementation notes: specific, not generic, tied to your stack.</li>
+      <li>Cross-verification notes: where multi-agent review surfaced a finding single-review assessments miss.</li>
+    </ul>
+    <p class="status-note">A sample anonymized deliverable will be published when the audit-product spec is complete.</p>
+  </section>
+
   <section class="section service-grid three">
     <article>
       <h2>Standard</h2>
       <p class="price">$797</p>
-      <p>Core audit, 5-pillar review, implementation priorities, PDF delivery.</p>
+      <p>Core audit. All five pillars. Implementation priorities. PDF delivery within 72 hours.</p>
+      <p class="status-note">Ordering opens July 2026.</p>
     </article>
     <article>
       <h2>Pro</h2>
       <p class="price">$1,497</p>
-      <p>Standard audit plus deeper architecture review and operator walkthrough.</p>
+      <p>Standard audit plus deeper architecture review, operator walkthrough call, and prioritized remediation plan.</p>
+      <p class="status-note">Ordering opens July 2026.</p>
     </article>
     <article>
       <h2>Bespoke</h2>
       <p class="price">Scoped</p>
-      <p>For operators who need system design, remediation, and delivery support.</p>
+      <p>For operators who need system design, hands-on remediation, and delivery support alongside the findings.</p>
+      <p class="status-note">Scope and availability at launch.</p>
     </article>
   </section>
+
   <section class="section narrow panel muted-panel">
     <h2>Ordering is not live yet.</h2>
-    <p>Stripe Checkout, intake routing, and SLA clock semantics require operator approval before the audit can be sold publicly.</p>
-    <a class="button primary" href="/waitlist/">Join launch list</a>
+    <p>Stripe Checkout, intake routing, and SLA clock semantics require operator approval before the audit can be sold publicly. The waitlist captures interest in the meantime.</p>
+    <a class="button primary" href="/waitlist/">Join the launch list</a>
+  </section>
+
+  <section class="section faq narrow">
+    <h2>Questions</h2>
+    <article><h3>How long does the audit take?</h3><p>72 business hours from when intake is complete and payment is confirmed. The SLA clock starts when both conditions are met, not at form submission.</p></article>
+    <article><h3>What do you need from me?</h3><p>A short inventory of your current AI tools, automation workflows, and access to read-only artifacts such as configs, audit logs, and existing documentation. We send a structured intake form after booking.</p></article>
+    <article><h3>Is this just a checklist?</h3><p>No. The findings are specific to your stack, not template-mapped. Multi-agent cross-verification is what produces the findings column that single-model assessments miss.</p></article>
+    <article><h3>What if I am not technical?</h3><p>The deliverable is written for operators, not engineers. Findings are risk-level-rated; remediation priorities are ordered by business impact, not complexity.</p></article>
   </section>
 </BaseLayout>

--- a/marketing-site/src/pages/audit.astro
+++ b/marketing-site/src/pages/audit.astro
@@ -1,7 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<BaseLayout title="AI Sovereignty Audit | Efficient Labs">
+<BaseLayout
+  title="AI Sovereignty Audit | Efficient Labs"
+  description="A 72-business-hour audit of automation risk, ownership boundaries, agent governance, secrets posture, and implementation gaps."
+  canonicalPath="/audit/"
+>
   <section class="page-hero narrow">
     <h1>72-hour AI Sovereignty Audit.</h1>
     <p>A structured review of your automation risk, ownership boundaries, agent governance, and implementation gaps. Not consulting-speak. Findings you can act on this week.</p>

--- a/marketing-site/src/pages/index.astro
+++ b/marketing-site/src/pages/index.astro
@@ -1,7 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<BaseLayout title="Efficient Labs | Governed AI Infrastructure">
+<BaseLayout
+  title="Efficient Labs | Governed AI Infrastructure"
+  description="Governed AI infrastructure, sovereign substrate, and audit-grade evidence for operators who refuse chaos."
+  canonicalPath="/"
+>
   <section class="hero section-grid">
     <div class="hero-copy">
       <h1>AI infrastructure for operators who refuse chaos.</h1>

--- a/marketing-site/src/pages/index.astro
+++ b/marketing-site/src/pages/index.astro
@@ -5,12 +5,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <section class="hero section-grid">
     <div class="hero-copy">
       <h1>AI infrastructure for operators who refuse chaos.</h1>
-      <p class="lead">Multi-agent governance, sovereign substrate, audit-grade evidence. Built in public; receipts on GitHub.</p>
+      <p class="lead">Multi-agent governance, sovereign substrate, audit-grade evidence. Built in public. Receipts on GitHub.</p>
       <div class="hero-actions">
         <a class="button primary" href="/waitlist/">Join the waitlist</a>
-        <a class="button secondary" href="/audit/">View the audit</a>
+        <a class="button secondary" href="/audit/">See the audit outline</a>
       </div>
-      <p class="launch-note">July 2026 launch. Waitlist and audit ordering are not live yet.</p>
+      <p class="launch-note">July 2026 launch. Waitlist and ordering are not live yet.</p>
     </div>
     <div class="hero-visual" aria-label="Efficient Labs infrastructure map">
       <img src="/architecture-signal.svg" alt="Governed AI infrastructure map" />
@@ -19,54 +19,75 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   <section class="section narrow">
     <h2>What this is</h2>
-    <p>Efficient Labs builds AI automation that can survive hard questions. The work is designed for operators who need clear ownership, audit trails, private client boundaries, and workflows that do not collapse into manual patchwork after the demo.</p>
+    <p>Efficient Labs builds AI automation that can survive hard questions.</p>
+    <p>The work is designed for operators who need clear ownership, audit trails, private client data boundaries, and workflows that do not collapse into manual patchwork after the first real deployment.</p>
+    <p>No demoware. No lock-in to a vendor scaffold. Infrastructure you can inspect, run yourself, and hand to an auditor.</p>
   </section>
 
   <section class="section band">
     <div class="section-heading">
       <h2>Public discipline. Private client data.</h2>
-      <p>Architecture decisions, runbooks, and public-safe evidence live in GitHub. Client workflows, intake artifacts, and business data stay in private repositories and controlled systems.</p>
+      <p>Architecture decisions, runbooks, and public-safe evidence live on GitHub. Client workflows, intake artifacts, and business data stay in private repositories and controlled systems.</p>
     </div>
     <div class="evidence-list">
       <article>
         <span>01</span>
         <h3>Architecture records</h3>
-        <p>Load-bearing decisions are documented with rollback logic and scope boundaries.</p>
+        <p>Load-bearing decisions are documented with scope boundaries and rollback logic.</p>
       </article>
       <article>
         <span>02</span>
         <h3>Hardened substrate</h3>
-        <p>VPS, Tailscale, audit logs, and agent boundaries are treated as product infrastructure.</p>
+        <p>Infrastructure is treated as product: access controls, audit logs, and agent boundaries are first-class.</p>
       </article>
       <article>
         <span>03</span>
         <h3>Governed agents</h3>
-        <p>Claude, Codex, Gemini, and operator gates work through task queues and review artifacts.</p>
+        <p>Multiple AI agents work through task queues and operator-review gates, not open-ended prompting.</p>
       </article>
     </div>
   </section>
 
   <section class="section services">
     <div>
-      <h2>Launch services</h2>
-      <p>These offers stay in local preview until Stripe, intake, and operator launch gates clear.</p>
+      <h2>What we deliver</h2>
+      <p>Three offers, each scoped to a different stage of readiness.</p>
     </div>
     <div class="service-grid">
       <article>
         <h3>AI Sovereignty Audit</h3>
-        <p>72-hour review of automation risk, ownership, governance, and implementation gaps.</p>
-        <a href="/audit/">Read audit outline</a>
+        <p>What your automation stack actually owns, what it exposes, and what to fix first. 72-hour turnaround. Deliverable: PDF findings report.</p>
+        <p class="status-note">Ordering opens July 2026.</p>
+        <a href="/audit/">Read the audit outline</a>
       </article>
       <article>
         <h3>Sovereign Stack Setup</h3>
-        <p>Practical buildout for operators ready to own their AI fulfillment substrate.</p>
-        <a href="/waitlist/">Join launch list</a>
+        <p>Practical buildout for operators ready to own their AI fulfillment substrate. From agents to substrate to task routing, built and handed over.</p>
+        <p class="status-note">Scope and availability at launch.</p>
+        <a href="/waitlist/">Join the launch list</a>
       </article>
       <article>
         <h3>Embedded Architect</h3>
-        <p>Ongoing architecture, review, and automation delivery for growing operators.</p>
-        <a href="/methodology/">See methodology</a>
+        <p>Ongoing architecture, review, and automation delivery for operators scaling past solo execution.</p>
+        <p class="status-note">Scoped engagements from launch.</p>
+        <a href="/methodology/">See the methodology</a>
       </article>
+    </div>
+  </section>
+
+  <section class="section narrow proof-section">
+    <h2>Built in public. Everything verifiable.</h2>
+    <p>The methodology is open source. The decision log is on GitHub. The agent coordination framework, Orchestral, is MIT-licensed.</p>
+    <p>If you want to understand how we work before you engage, you do not have to ask. Read the commits.</p>
+    <a class="button secondary" href="https://github.com/Neo-The-Architect/Orchestral">Read Orchestral on GitHub</a>
+    <p class="status-note">Orchestral v0.3 public methodology content ships before launch.</p>
+  </section>
+
+  <section class="section final-cta">
+    <div>
+      <h2>You are early. The infrastructure is not.</h2>
+      <p>Most operators who find us find us before launch. That is intentional. The waitlist captures interest. Priority booking goes to waitlist members. Ordering opens July 2026.</p>
+      <a class="button primary" href="/waitlist/">Join the waitlist</a>
     </div>
   </section>
 </BaseLayout>

--- a/marketing-site/src/pages/methodology.astro
+++ b/marketing-site/src/pages/methodology.astro
@@ -1,7 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<BaseLayout title="Methodology | Efficient Labs">
+<BaseLayout
+  title="Methodology | Efficient Labs"
+  description="The public methodology behind Efficient Labs: operator gates, multi-agent execution boundaries, and evidence trails by default."
+  canonicalPath="/methodology/"
+>
   <section class="page-hero narrow">
     <h1>The methodology is public.</h1>
     <p>Efficient Labs operates through Orchestral, a disciplined framework for one operator to govern multiple AI agents, task queues, evidence artifacts, and launch gates without losing control of the business.</p>

--- a/marketing-site/src/pages/methodology.astro
+++ b/marketing-site/src/pages/methodology.astro
@@ -4,26 +4,64 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="Methodology | Efficient Labs">
   <section class="page-hero narrow">
     <h1>The methodology is public.</h1>
-    <p>Efficient Labs operates through Orchestral: a disciplined way for one operator to govern multiple AI agents, task queues, evidence artifacts, and launch gates without losing control of the business.</p>
+    <p>Efficient Labs operates through Orchestral, a disciplined framework for one operator to govern multiple AI agents, task queues, evidence artifacts, and launch gates without losing control of the business.</p>
+    <a class="button secondary" href="https://github.com/Neo-The-Architect/Orchestral">Read Orchestral on GitHub</a>
+    <p class="status-note">Orchestral v0.3 methodology content ships before launch. The repo link is live; content depth lands with the v0.3 PR.</p>
+  </section>
+
+  <section class="section band">
+    <div class="section-heading"><h2>Three principles. Applied to every engagement.</h2></div>
+    <div class="evidence-list">
+      <article><span>Govern</span><h3>Operator gates everywhere</h3><p>Secrets, spend, public launch actions, and infrastructure risk require explicit human approval. Agents propose; operators decide.</p></article>
+      <article><span>Build</span><h3>Agent execution with clean boundaries</h3><p>Claude, Codex, and Gemini each have defined roles, read/write scopes, and task-queue constraints. No open-ended prompting on production systems.</p></article>
+      <article><span>Prove</span><h3>Evidence trail by default</h3><p>Every capability promotion needs classification, smoke tests, and documented decision boundaries. If you cannot point to the artifact, it did not happen.</p></article>
+    </div>
+  </section>
+
+  <section class="section narrow">
+    <h2>Orchestral: open-source, operator-agnostic</h2>
+    <p>Orchestral is the methodology, not the product. It defines how a solo operator governs a multi-agent system: role boundaries, coordination patterns, earned-complexity discipline, and the vault structure that makes audit possible.</p>
+    <p>It is MIT-licensed. You can adopt it without engaging Efficient Labs.</p>
+    <p>If you want the infrastructure built for you, or an audit of what you have already built, that is where the commercial offer begins.</p>
     <a class="button secondary" href="https://github.com/Neo-The-Architect/Orchestral">Read Orchestral on GitHub</a>
   </section>
-  <section class="section band">
-    <div class="evidence-list">
-      <article>
-        <span>Govern</span>
-        <h2>Operator gates</h2>
-        <p>Secrets, spend, public launch actions, and infrastructure risk require explicit human approval.</p>
-      </article>
-      <article>
-        <span>Build</span>
-        <h2>Agent execution</h2>
-        <p>Claude, Codex, and Gemini split planning, implementation, and review through durable artifacts.</p>
-      </article>
-      <article>
-        <span>Prove</span>
-        <h2>Evidence trail</h2>
-        <p>Every capability promotion needs classification, smoke tests, and documented boundaries.</p>
-      </article>
+
+  <section class="section narrow">
+    <h2>We do not build what you do not need yet.</h2>
+    <p>Most AI automation projects fail not because of the technology, but because complexity accumulates faster than it is governed.</p>
+    <p>We apply a strict discipline: no system surface is built until its absence has caused a documented failure. Every addition requires a journaled reason. Every deferral is logged.</p>
+    <p>The result: systems that stay legible, maintainable, and auditable as they grow.</p>
+  </section>
+
+  <section class="section narrow">
+    <h2>How a client engagement works</h2>
+    <div class="table-wrap">
+      <table>
+        <tbody>
+          <tr><th>Intake</th><td>Structured form captures your current stack, goals, and constraints. SLA clock starts when intake is complete and payment is confirmed.</td></tr>
+          <tr><th>Audit or buildout</th><td>Agents assess or build per the Orchestral framework. Cross-verification pass on findings before delivery.</td></tr>
+          <tr><th>Delivery</th><td>PDF report for audits, or documented infrastructure handover for buildout. Operator walkthrough on Pro tier.</td></tr>
+          <tr><th>Post-delivery</th><td>Async Q&A for scoped tiers. Standard tier is delivery-complete.</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="status-note">Full engagement protocols are published after operator approval. The table reflects current design intent, not a binding contract.</p>
+  </section>
+
+  <section class="section narrow proof-section">
+    <h2>Proof, not claims.</h2>
+    <p>The architecture behind this site, including agent coordination, task queuing, and hardening evidence, is the same infrastructure we use for client work.</p>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Proof asset</th><th>Status</th></tr></thead>
+        <tbody>
+          <tr><td>Efficient Labs public repo</td><td>In progress</td></tr>
+          <tr><td>Orchestral v0.3 methodology content</td><td>Scheduled before launch</td></tr>
+          <tr><td>Sanitized build-in-public case study</td><td>Pending approval</td></tr>
+          <tr><td>Sample anonymized audit deliverable</td><td>Pending audit-product spec</td></tr>
+          <tr><td>Lynis hardening evidence pack</td><td>Evidence captured</td></tr>
+        </tbody>
+      </table>
     </div>
   </section>
 </BaseLayout>

--- a/marketing-site/src/pages/waitlist.astro
+++ b/marketing-site/src/pages/waitlist.astro
@@ -1,7 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<BaseLayout title="Waitlist | Efficient Labs">
+<BaseLayout
+  title="Waitlist | Efficient Labs"
+  description="Join the Efficient Labs launch waitlist for priority booking and launch-week updates before public ordering opens."
+  canonicalPath="/waitlist/"
+>
   <section class="page-hero narrow">
     <h1>You are early. We launch July 2026.</h1>
     <p>Join the waitlist for priority booking and launch-week updates. No spam. One email when the door opens.</p>

--- a/marketing-site/src/pages/waitlist.astro
+++ b/marketing-site/src/pages/waitlist.astro
@@ -4,14 +4,42 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="Waitlist | Efficient Labs">
   <section class="page-hero narrow">
     <h1>You are early. We launch July 2026.</h1>
-    <p>Join the waitlist for priority booking and launch-week updates. The live form backend is intentionally disabled until the waitlist storage gate clears.</p>
+    <p>Join the waitlist for priority booking and launch-week updates. No spam. One email when the door opens.</p>
+    <p class="status-note">The form backend is not live. Cloudflare Worker plus storage topology decision pending operator gate.</p>
   </section>
+
   <section class="section form-section">
     <form class="panel" aria-describedby="waitlist-status">
       <label for="email">Email</label>
       <input id="email" name="email" type="email" placeholder="you@example.com" disabled />
       <button type="button" disabled>Waitlist opens soon</button>
-      <p id="waitlist-status">Backend pending: Cloudflare Worker plus canonical storage decision.</p>
+      <p id="waitlist-status">Backend pending: operator storage gate.</p>
     </form>
+  </section>
+
+  <section class="section narrow">
+    <h2>What waitlist members get</h2>
+    <div class="table-wrap">
+      <table>
+        <tbody>
+          <tr><th>Priority booking</th><td>First access to the AI Sovereignty Audit and Sovereign Stack Setup engagements at launch.</td></tr>
+          <tr><th>Launch-week rate</th><td>Audit at Standard rate held for 30 days post-launch for waitlist members.</td></tr>
+          <tr><th>Build-in-public updates</th><td>Architectural decisions, methodology releases, and infrastructure milestones as they ship, with no noise.</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="status-note">Prices are indicative. Confirmed at launch.</p>
+  </section>
+
+  <section class="section band">
+    <div class="section-heading">
+      <h2>Why this is different</h2>
+      <p>Every claim on this site is backed by public artifacts. If you want to verify before you sign up, you can.</p>
+    </div>
+    <div class="evidence-list">
+      <article><span>GitHub</span><h3>Commits and decisions</h3><p>Architecture records, runbooks, and launch artifacts are public-safe by default.</p></article>
+      <article><span>Orchestral</span><h3>Open methodology</h3><p>The operating framework is visible before any commercial engagement starts.</p></article>
+      <article><span>Case study</span><h3>Sanitized proof</h3><p>Build-in-public retrospectives publish only after sanitizer and operator approval.</p></article>
+    </div>
   </section>
 </BaseLayout>

--- a/marketing-site/src/styles/global.css
+++ b/marketing-site/src/styles/global.css
@@ -77,3 +77,19 @@ button { min-height: 46px; border: 0; border-radius: 8px; margin-top: 14px; padd
   .evidence-list, .service-grid { grid-template-columns: 1fr; }
   .site-footer { flex-direction: column; }
 }
+
+.status-note { color: var(--muted); font-size: 14px !important; line-height: 1.5 !important; margin-top: 14px; }
+.proof-section .button { margin-top: 12px; }
+.final-cta { background: #ebe5d8; max-width: none; padding-left: max(16px, calc((100% - var(--max)) / 2)); padding-right: max(16px, calc((100% - var(--max)) / 2)); }
+.final-cta > div { max-width: 780px; }
+.table-wrap { overflow-x: auto; margin-top: 22px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); }
+table { width: 100%; border-collapse: collapse; min-width: 620px; }
+th, td { text-align: left; vertical-align: top; padding: 16px; border-bottom: 1px solid var(--line); line-height: 1.5; }
+tr:last-child th, tr:last-child td { border-bottom: 0; }
+th { width: 28%; font-weight: 800; color: var(--ink); }
+td { color: var(--muted); }
+.check-list { padding-left: 20px; color: var(--muted); font-size: 18px; line-height: 1.65; }
+.check-list li + li { margin-top: 8px; }
+.faq article { border-top: 1px solid var(--line); padding: 22px 0; }
+.faq article:last-child { border-bottom: 1px solid var(--line); }
+.three { width: min(var(--max), calc(100% - 32px)); margin-left: auto; margin-right: auto; }

--- a/marketing-site/src/styles/global.css
+++ b/marketing-site/src/styles/global.css
@@ -78,16 +78,16 @@ button { min-height: 46px; border: 0; border-radius: 8px; margin-top: 14px; padd
   .site-footer { flex-direction: column; }
 }
 
-.status-note { color: var(--muted); font-size: 14px !important; line-height: 1.5 !important; margin-top: 14px; }
+.status-note, .section p.status-note, .page-hero p.status-note { color: var(--muted); font-size: 14px; line-height: 1.5; margin-top: 14px; }
 .proof-section .button { margin-top: 12px; }
 .final-cta { background: #ebe5d8; max-width: none; padding-left: max(16px, calc((100% - var(--max)) / 2)); padding-right: max(16px, calc((100% - var(--max)) / 2)); }
 .final-cta > div { max-width: 780px; }
 .table-wrap { overflow-x: auto; margin-top: 22px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); }
-table { width: 100%; border-collapse: collapse; min-width: 620px; }
-th, td { text-align: left; vertical-align: top; padding: 16px; border-bottom: 1px solid var(--line); line-height: 1.5; }
-tr:last-child th, tr:last-child td { border-bottom: 0; }
-th { width: 28%; font-weight: 800; color: var(--ink); }
-td { color: var(--muted); }
+.table-wrap table { width: 100%; border-collapse: collapse; min-width: 620px; }
+.table-wrap th, .table-wrap td { text-align: left; vertical-align: top; padding: 16px; border-bottom: 1px solid var(--line); line-height: 1.5; }
+.table-wrap tr:last-child th, .table-wrap tr:last-child td { border-bottom: 0; }
+.table-wrap th { width: 28%; font-weight: 800; color: var(--ink); }
+.table-wrap td { color: var(--muted); }
 .check-list { padding-left: 20px; color: var(--muted); font-size: 18px; line-height: 1.65; }
 .check-list li + li { margin-top: 8px; }
 .faq article { border-top: 1px solid var(--line); padding: 22px 0; }


### PR DESCRIPTION
## Summary
- apply the operator-approved launch-site copy pack to the home, waitlist, audit, and methodology pages
- preserve disabled/non-live waitlist and audit order states
- add supporting table/list styles for audit and methodology copy

## Verification
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate` -> 0 vulnerabilities
- local preview curl: `/`, `/waitlist/`, `/audit/`, `/methodology/` all HTTP 200
- grep sweep for gate/proof markers, live checkout/order language, analytics/pixel/form action

## Launch boundary
- No public deploy
- No DNS change
- No live form backend
- No Stripe live mode
- No tracking pixels

Anonymization grep clean ? verified zero matches against canonical private-brand exclusion list at commit time. Operator maintains the canonical list privately.
