### PR TITLE
feat(audit-intake): internal n8n workflow + Tally build guide (Task 6)

### DIFF
--- a/n8n-archetypes/internal-audit-intake-tally-build-guide.md
+++ b/n8n-archetypes/internal-audit-intake-tally-build-guide.md
@@ -1,0 +1,249 @@
+# Tally form build guide — AI Sovereignty Audit Intake
+
+**Audience:** operator (Michael / NeoTheArchitect)
+**Time budget:** ~20 minutes in the Tally UI
+**Webhook target (live + tested 2026-05-25):** `https://n8n.efficientlabs.ai/webhook/audit-intake`
+
+This guide walks you through creating the canonical AI Sovereignty Audit intake form in Tally. The n8n workflow that receives the webhook is already built, tested, and active (see `internal-audit-intake-workflow.json` + ADR-0022). All you need to do is build the form and wire the webhook.
+
+---
+
+## Step 1. Create the form
+
+1. Sign in at https://tally.so
+2. Click **+ Create form**
+3. Choose **Start from scratch**
+4. Title: **AI Sovereignty Audit — Intake**
+5. Description (optional, shown on form): *Tell us about your automation stack. We'll use this to scope your audit deliverable.*
+6. **Save** to create the form draft.
+
+---
+
+## Step 2. Add fields (in this exact order)
+
+For each field below: click **+ Add question**, pick the type, then enable **Question settings → Field key (custom)** and paste the exact `key` string. The `key` is what n8n reads — UI label text is for the human user.
+
+### Required fields (visible by default)
+
+| # | Type | `key` (custom) | Label (UI) | Required? |
+|---|---|---|---|---|
+| 1 | Short answer | `client_legal_name` | Legal Company Name | ✅ |
+| 2 | Short answer | `client_contact_name` | Your Name | ✅ |
+| 3 | Email | `client_email` | Best Email to Reach You | ✅ |
+| 4 | Dropdown | `client_industry` | Industry | ✅ |
+| 5 | Long answer | `pain_point` | Biggest pain point with your current automation (1-3 sentences, be specific) | ✅ |
+
+For the `client_industry` dropdown, paste these options exactly:
+
+```
+technology
+healthcare
+finance
+retail
+professional-services
+manufacturing
+education
+nonprofit
+media
+other
+```
+
+### Conditional reveals
+
+Tally supports "show this question if..." logic. Set these up after adding the base fields:
+
+- **`client_industry_note`** (Short answer): show only if `client_industry == other`. Label: *If "other", please describe your industry briefly.* Required when shown.
+
+### Optional fields (group below required fields)
+
+| # | Type | `key` | Label |
+|---|---|---|---|
+| 6 | Short answer | `client_role` | Your Role / Title |
+| 7 | Number | `client_locations` | Number of business locations |
+| 8 | Dropdown | `client_revenue` | Annual revenue range |
+| 9 | Short answer | `workflow_name` | Name of your most-broken workflow |
+| 10 | Dropdown | `workflow_platform` | Current automation platform |
+| 11 | Long answer | `workflow_description` | Describe what it does (and what breaks) |
+| 12 | Number | `workflow_breaks` | Estimated breaks per quarter |
+| 13 | Number | `workflow_hours` | Maintenance hours per quarter |
+| 14 | Checkbox | `workflow_pii` | This workflow touches personally-identifiable data (PII) |
+| 15 | Checkbox | `workflow_payments` | This workflow touches payment data |
+| 16 | Checkbox | `workflow_health` | This workflow touches health data |
+| 17 | Dropdown | `workflow_priority` | Migration priority |
+| 18 | Dropdown | `sovereignty_cloud` | Current primary cloud |
+| 19 | Checkbox | `sovereignty_concern` | I have explicit sovereignty / data-residency concerns |
+| 20 | Long answer | `sovereignty_note` | (conditional, shown if `sovereignty_concern` checked) Describe your sovereignty concerns |
+| 21 | Checkbox | `sovereignty_regulated` | I operate in a regulated industry |
+| 22 | Multi-select | `sovereignty_regulations` | (conditional, shown if `sovereignty_regulated` checked) Which regulations apply? |
+| 23 | Dropdown | `budget_tier` | Audit tier |
+| 24 | Dropdown | `budget_implementation` | Expected implementation budget range |
+| 25 | Dropdown | `budget_retainer` | Expected monthly retainer budget |
+| 26 | Dropdown | `budget_urgency` | Timeline urgency |
+| 27 | Long answer | `success_criteria` | What does success look like? |
+| 28 | Long answer | `constraints` | Constraints or caveats we should know about |
+
+### Dropdown values (paste these into each respective field)
+
+**`client_revenue`:**
+```
+pre-revenue
+under-100k
+100k-1m
+1m-10m
+10m-100m
+over-100m
+prefer-not-to-say
+```
+
+**`workflow_platform`:**
+```
+zapier
+n8n
+make
+power-automate
+workato
+custom-code
+none-manual
+other
+```
+
+**`workflow_priority`:**
+```
+low
+medium
+high
+critical-blocker
+```
+
+**`sovereignty_cloud`:**
+```
+aws
+gcp
+azure
+oracle
+digitalocean
+multi-cloud
+on-prem
+none
+other
+```
+
+**`sovereignty_regulations`** (multi-select):
+```
+HIPAA
+GDPR
+CCPA
+SOC2
+PCI-DSS
+GLBA
+FedRAMP
+ITAR
+Other
+```
+
+**`budget_tier`:**
+```
+standard
+sovereign
+bespoke
+```
+
+**`budget_implementation`:**
+```
+no-budget-yet
+under-1k
+1k-5k
+5k-10k
+10k-25k
+25k-100k
+over-100k
+```
+
+**`budget_retainer`:**
+```
+no-retainer
+under-500
+500-2k
+2k-5k
+5k-15k
+over-15k
+```
+
+**`budget_urgency`:**
+```
+exploratory
+in-evaluation
+ready-to-buy
+actively-implementing-elsewhere
+```
+
+---
+
+## Step 3. Wire the webhook
+
+1. In Tally, open your form → **Integrations** tab (top right)
+2. Find **Webhooks** → **Connect**
+3. Webhook URL: `https://n8n.efficientlabs.ai/webhook/audit-intake`
+4. HTTP method: **POST** (default)
+5. Triggers: **Form responses** (checked)
+6. Save.
+
+You do NOT need a signing secret in Tally — the n8n workflow doesn't enforce one yet (TODO post-launch: add HMAC signature verification, mirrors archetypes 02/06).
+
+---
+
+## Step 4. Publish + test
+
+1. Tally → **Publish** your form. Copy the live URL.
+2. Open the live URL in an incognito tab.
+3. Submit one form response with realistic-but-fake data and **your own email** as `client_email`.
+4. Verify within ~2 minutes:
+   - You receive an email at `founder@efficientlabs.ai` titled `🚨 New audit intake — <client name>`
+   - The email you used as `client_email` receives a confirmation titled `Your AI Sovereignty Audit submission — Efficient Labs`
+   - The intake document appears in MemCompute under `intake-gate/intake_<timestamp>_<hash>.md` — check via:
+     ```bash
+     /home/neo/bin/mem-handoff inbox operator  # Telegram fired the operator email already
+     # or directly:
+     curl -sH "Authorization: Bearer $(grep MEMCOMPUTE_BEARER_TOKEN ~/.config/sovereign-core/vault.env | cut -d= -f2)" \
+       'http://100.83.59.73:8767/directories/intake-gate/'
+     ```
+
+If all three land, the loop is operational and you're ready to publish the Tally URL on the marketing site.
+
+---
+
+## Marketing site CTA wiring (after publish)
+
+Once the form is live in Tally, grab its URL (`tally.so/r/<form-id>`). Update the marketing site CTA button:
+
+- `~/work/Efficient-Labs/marketing-site/src/...` — wherever the "Start your audit" button lives
+- Set the `href` to the Tally URL (or wrap it in a tracking redirect if you want analytics)
+
+Open a separate PR for the marketing-site CTA wiring (not in this PR).
+
+---
+
+## What happens after a submission
+
+1. Tally → POST → `https://n8n.efficientlabs.ai/webhook/audit-intake` (via Cloudflare Tunnel → host's n8n via `--network host`)
+2. n8n **Validate + normalize** Code node: indexes fields, validates required + conditional rules, generates `intake_<ts>_<hash>` ID, builds normalized IntakeRecord
+3. n8n **If validation passed** branch:
+   - ✅ → **PUT intake to MemCompute** under `intake-gate/<intake_id>.md` (frontmatter for indexability, body has full record JSON)
+   - ✅ → **Notify operator (Resend)** to `founder@efficientlabs.ai` with client name, email, industry, tier, pain-point excerpt, link to MemCompute UI
+   - ✅ → **Confirm to client (Resend)** with intake ID, next-steps language, brand voice
+   - ✅ → Respond OK to Tally
+   - ✗ → Respond fail (Tally still receives 200; user sees Tally's default confirmation)
+4. Operator follows up within 24h with Stripe payment link + scoping call invite (manual for v1; automated in v1.1)
+
+---
+
+## Known limits + post-launch work
+
+- No HMAC verification on the webhook (Tally doesn't sign requests by default; n8n trusts Cloudflare Tunnel as the gate)
+- Validation logic in n8n's Code node is a one-time copy of `sovereign-core/tools/efficient_labs_audit_intake.js` — if the spec changes, both must update
+- Stripe checkout is OUT of the Tally loop for v1 — payment link sent manually post-submission. v1.1 will embed Checkout directly
+- Intake records live in MemCompute under `intake-gate/`; sovereign-core stage 1 doesn't yet poll this path (post-launch follow-up: add a sovereign-core bridge that picks up from MemCompute → 01_intake_gate/working/)
+
+---
+
+*Built 2026-05-25 by Claude Opus 4.7 + Operator (handoff). Tested end-to-end against synthetic payloads — both success and validation-fail paths verified.*

--- a/n8n-archetypes/internal-audit-intake-workflow.json
+++ b/n8n-archetypes/internal-audit-intake-workflow.json
@@ -1,0 +1,266 @@
+{
+  "name": "audit-intake \u2014 Tally webhook \u2192 MemCompute + Resend",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "audit-intake",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook (audit-intake)",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        240,
+        400
+      ],
+      "webhookId": "audit-intake"
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "function randHex(n) {\n  const chars = '0123456789abcdef';\n  let s = '';\n  for (let i = 0; i < n * 2; i++) s += chars[Math.floor(Math.random() * 16)];\n  return s;\n}\n\nfunction smallHash(str) {\n  // FNV-1a-ish \u2014 non-cryptographic, just a stable short id derived from content\n  let h = 2166136261;\n  for (let i = 0; i < str.length; i++) {\n    h ^= str.charCodeAt(i);\n    h = Math.imul(h, 16777619);\n  }\n  return (h >>> 0).toString(16).padStart(8, '0');\n}\n\nconst raw = $input.first().json;\nconst tallyData = raw.data || raw.body?.data || {};\nconst fields = tallyData.fields || [];\n\nconst fieldMap = {};\nfor (const f of fields) {\n  if (f && f.key) fieldMap[f.key] = f.value;\n}\n\nconst submissionId = tallyData.submissionId || fieldMap['submission_id'] || 'sub_' + randHex(8);\nconst stripeSessionId = fieldMap['stripe_checkout_session_id'] || null;\n\nconst submission = {\n  submission_id: submissionId,\n  submitted_at: tallyData.createdAt || new Date().toISOString(),\n  stripe_checkout_session_id: stripeSessionId,\n  client: {\n    legal_name: fieldMap['client_legal_name'] || fieldMap['legal_name'] || '',\n    primary_contact_name: fieldMap['client_contact_name'] || fieldMap['primary_contact_name'] || '',\n    primary_contact_email: fieldMap['client_email'] || fieldMap['primary_contact_email'] || '',\n    role_title: fieldMap['client_role'] || fieldMap['role_title'] || null,\n    industry: fieldMap['client_industry'] || fieldMap['industry'] || 'other',\n    industry_other_note: fieldMap['client_industry_note'] || fieldMap['industry_other_note'] || null,\n    location_count: parseInt(fieldMap['client_locations'] || fieldMap['location_count'] || '1', 10),\n    annual_revenue_range: fieldMap['client_revenue'] || fieldMap['annual_revenue_range'] || 'prefer-not-to-say',\n  },\n  existing_workflows: Array.isArray(fieldMap['existing_workflows']) ? fieldMap['existing_workflows'] : [{\n    workflow_name: fieldMap['workflow_name'] || 'Core Ops Workflow',\n    current_platform: fieldMap['workflow_platform'] || 'zapier',\n    current_platform_other_note: fieldMap['workflow_platform_note'] || null,\n    description: fieldMap['workflow_description'] || 'Default workflow details.',\n    breaks_per_quarter_estimate: parseInt(fieldMap['workflow_breaks'] || '0', 10),\n    maintenance_hours_per_quarter_estimate: parseFloat(fieldMap['workflow_hours'] || '0'),\n    touches_pii: fieldMap['workflow_pii'] === true || fieldMap['workflow_pii'] === 'true',\n    touches_payment_data: fieldMap['workflow_payments'] === true || fieldMap['workflow_payments'] === 'true',\n    touches_health_data: fieldMap['workflow_health'] === true || fieldMap['workflow_health'] === 'true',\n    migration_priority: fieldMap['workflow_priority'] || 'medium',\n  }],\n  integration_requests: Array.isArray(fieldMap['integration_requests']) ? fieldMap['integration_requests'] : [],\n  sovereignty: {\n    current_primary_cloud: fieldMap['sovereignty_cloud'] || 'none',\n    explicit_sovereignty_concern: fieldMap['sovereignty_concern'] === true || fieldMap['sovereignty_concern'] === 'true',\n    sovereignty_concern_note: fieldMap['sovereignty_note'] || null,\n    regulated_industry_flag: fieldMap['sovereignty_regulated'] === true || fieldMap['sovereignty_regulated'] === 'true',\n    regulation_names: Array.isArray(fieldMap['sovereignty_regulations']) ? fieldMap['sovereignty_regulations'] : [],\n  },\n  budget: {\n    audit_tier_purchased: fieldMap['budget_tier'] || 'standard',\n    expected_implementation_budget_usd_range: fieldMap['budget_implementation'] || 'no-budget-yet',\n    expected_retainer_budget_usd_monthly: fieldMap['budget_retainer'] || 'no-retainer',\n    timeline_urgency: fieldMap['budget_urgency'] || 'exploratory',\n  },\n  biggest_pain_point: fieldMap['pain_point'] || 'No main pain point provided.',\n  what_success_looks_like: fieldMap['success_criteria'] || null,\n  constraints_or_caveats: fieldMap['constraints'] || null,\n};\n\nconst errors = [];\nif (!submission.client.legal_name || submission.client.legal_name.length < 2) errors.push('client.legal_name must be at least 2 chars.');\nif (!submission.client.primary_contact_email || !submission.client.primary_contact_email.includes('@')) errors.push('client.primary_contact_email must be a valid email address.');\nif (submission.client.industry === 'other' && !submission.client.industry_other_note) errors.push('industry_other_note is required when industry is other.');\nif (submission.biggest_pain_point.length < 10) errors.push('biggest_pain_point must be at least 10 chars.');\n\nif (errors.length > 0) return [{ json: { ok: false, errors, submission_id: submissionId } }];\n\nconst ts = new Date().toISOString();\nconst dateStr = ts.replace(/[:.]/g, '-');\nconst hash = smallHash(JSON.stringify(submission));\nconst intakeId = 'intake_' + dateStr + '_' + hash;\n\nconst intakeRecord = {\n  id: intakeId,\n  received_at: ts,\n  input_type: 'webhook',\n  source: { channel: 'tally', form: 'audit-intake' },\n  normalized_payload: { intake_submission: submission },\n  quarantine_flags: [],\n  routing_hint: '02_reasoning_matrix',\n};\n\nreturn [{ json: { ok: true, intakeId, intakeRecord, summary: {\n  client_legal_name: submission.client.legal_name,\n  client_email: submission.client.primary_contact_email,\n  client_name: submission.client.primary_contact_name,\n  industry: submission.client.industry,\n  tier: submission.budget.audit_tier_purchased,\n  pain_excerpt: submission.biggest_pain_point.slice(0, 200),\n}}}];"
+      },
+      "id": "validate",
+      "name": "Validate + normalize",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        460,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.ok }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-ok",
+      "name": "If validation passed",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        680,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "=http://100.83.59.73:8767/documents/intake-gate/{{ $json.intakeId }}.md",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  frontmatter: {\n    intake_id: $json.intakeId,\n    received_at: $json.intakeRecord.received_at,\n    client: $json.summary.client_legal_name,\n    email: $json.summary.client_email,\n    industry: $json.summary.industry,\n    tier: $json.summary.tier,\n    source: 'tally-webhook',\n    status: 'open'\n  },\n  body: '# Intake ' + $json.intakeId + '\\n\\n```json\\n' + JSON.stringify($json.intakeRecord, null, 2) + '\\n```'\n}) }}",
+        "options": {}
+      },
+      "id": "mc-put",
+      "name": "PUT intake to MemCompute",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        900,
+        300
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "<replace-with-actual-id>",
+          "name": "MemCompute Bearer"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.resend.com/emails",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  from: 'founder@efficientlabs.ai',\n  to: ['founder@efficientlabs.ai'],\n  subject: '\ud83d\udea8 New audit intake \u2014 ' + $('Validate + normalize').first().json.summary.client_legal_name,\n  text: '## New audit intake submission\\n\\n' +\n        'Intake ID: ' + $('Validate + normalize').first().json.intakeId + '\\n' +\n        'Client: ' + $('Validate + normalize').first().json.summary.client_legal_name + '\\n' +\n        'Email: ' + $('Validate + normalize').first().json.summary.client_email + '\\n' +\n        'Industry: ' + $('Validate + normalize').first().json.summary.industry + '\\n' +\n        'Tier: ' + $('Validate + normalize').first().json.summary.tier + '\\n\\n' +\n        '## Pain point excerpt\\n' + $('Validate + normalize').first().json.summary.pain_excerpt + '\\n\\n' +\n        '## Next action\\nFollow up with payment link + scoping call within 24h.\\n\\n' +\n        '## Full intake record\\nhttp://100.83.59.73:8767/ui/#/intake-gate/' + $('Validate + normalize').first().json.intakeId + '.json'\n}) }}",
+        "options": {}
+      },
+      "id": "op-email",
+      "name": "Notify operator (Resend)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1120,
+        300
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "<replace-with-actual-id>",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.resend.com/emails",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  from: 'founder@efficientlabs.ai',\n  to: [$('Validate + normalize').first().json.summary.client_email],\n  subject: 'Your AI Sovereignty Audit submission \u2014 Efficient Labs',\n  text: 'Hi ' + ($('Validate + normalize').first().json.intakeRecord.normalized_payload.intake_submission.client.primary_contact_name || 'there') + ',\\n\\n' +\n        'Thank you for submitting your AI Sovereignty Audit intake. Your reference number is:\\n' +\n        '  ' + $('Validate + normalize').first().json.intakeId + '\\n\\n' +\n        'We have received the details for ' + $('Validate + normalize').first().json.summary.client_legal_name + '. The next step is a brief scoping call so we can confirm the audit scope and send the payment link.\\n\\n' +\n        'You will hear from us within 24 hours.\\n\\n' +\n        'If anything is urgent, reply to this email.\\n\\n' +\n        '\u2014 Michael Ward\\nFounder, Efficient Labs\\n  https://efficientlabs.ai'\n}) }}",
+        "options": {}
+      },
+      "id": "client-email",
+      "name": "Confirm to client (Resend)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1340,
+        300
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "<replace-with-actual-id>",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const r = $('Validate + normalize').first().json; return [{ json: { success: true, intake_id: r.intakeId, message: 'Intake received. Operator notified.' } }];"
+      },
+      "id": "respond-ok",
+      "name": "Respond OK",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1560,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const r = $input.first().json; return [{ json: { success: false, errors: r.errors, message: 'Validation failed; no intake stored.' } }];"
+      },
+      "id": "respond-fail",
+      "name": "Respond fail",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        900,
+        500
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook (audit-intake)": {
+      "main": [
+        [
+          {
+            "node": "Validate + normalize",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate + normalize": {
+      "main": [
+        [
+          {
+            "node": "If validation passed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "If validation passed": {
+      "main": [
+        [
+          {
+            "node": "PUT intake to MemCompute",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond fail",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "PUT intake to MemCompute": {
+      "main": [
+        [
+          {
+            "node": "Notify operator (Resend)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify operator (Resend)": {
+      "main": [
+        [
+          {
+            "node": "Confirm to client (Resend)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Confirm to client (Resend)": {
+      "main": [
+        [
+          {
+            "node": "Respond OK",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "_archetype_metadata": {
+    "description": "Internal audit-intake workflow for the Efficient Labs Tally form. NOT a client deliverable \u2014 this is the production intake pipeline for our own audit product. Lives in efficient-labs n8n at https://n8n.efficientlabs.ai.",
+    "authored": "2026-05-25",
+    "version": "1.0",
+    "authors": [
+      "Claude Opus 4.7",
+      "Operator (handoff)"
+    ],
+    "tested_with_fixtures": [
+      "tests/fixtures/tally-audit-intake-*.json from sovereign-core"
+    ],
+    "webhook_path": "/webhook/audit-intake",
+    "memcompute_target": "intake-gate/<intake_id>.md"
+  }
+}


### PR DESCRIPTION
## Summary
Ships the production audit-intake pipeline (operator's Task 6 — last task blocking launch readiness). Tally → n8n webhook → MemCompute → Resend operator+client. End-to-end tested.

## Verified working (2026-05-25)
- ✅ Workflow built via n8n API (id `44rID3Fapv84vALY`), active
- ✅ Both credentials created via API with `allowedHttpRequestDomains` scoping
- ✅ Success path: HTTP 200 in 1.4s, intake landed at `intake-gate/intake_2026-05-25T13-30-17-831Z_1524a18d.md`, both Resend emails fired
- ✅ Fail path: HTTP 200 `success:false` with structured validation errors, no downstream calls

## In this PR
| File | Purpose |
|---|---|
| `internal-audit-intake-workflow.json` | Production workflow JSON (credential IDs anonymized) |
| `internal-audit-intake-tally-build-guide.md` | 20-min operator walkthrough for Tally UI build |

## Companion ADR
Solo-AI: ADR-0022 (architectural decisions in a separate PR)

## Operator next step (~20 min)
Follow the build guide: tally.so → create form per field-key spec → webhook to `https://n8n.efficientlabs.ai/webhook/audit-intake` → submit a test → verify all 3 outcomes (operator email, client confirmation, MemCompute intake-gate write)

After that: 7/7 operator tasks complete, launch readiness achieved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)